### PR TITLE
Add live quote and minute chart support

### DIFF
--- a/src/dartlab/server/__init__.py
+++ b/src/dartlab/server/__init__.py
@@ -30,6 +30,7 @@ from .api import (
     dart_router,
     data_router,
     dl_router,
+    live_router,
     macro_router,
     price_events_router,
     room_router,
@@ -229,6 +230,7 @@ app.include_router(ask_router)
 app.include_router(company_router)
 app.include_router(data_router)
 app.include_router(dl_router)
+app.include_router(live_router)
 app.include_router(macro_router)
 app.include_router(price_events_router)
 app.include_router(room_router)

--- a/src/dartlab/server/api/__init__.py
+++ b/src/dartlab/server/api/__init__.py
@@ -6,6 +6,7 @@ from .company import router as company_router
 from .dart import router as dart_router
 from .data import router as data_router
 from .dl import router as dl_router
+from .live import router as live_router
 from .macro import router as macro_router
 from .priceEvents import router as price_events_router
 from .room import router as room_router
@@ -19,6 +20,7 @@ __all__ = [
     "dart_router",
     "data_router",
     "dl_router",
+    "live_router",
     "macro_router",
     "price_events_router",
     "room_router",

--- a/src/dartlab/server/api/live.py
+++ b/src/dartlab/server/api/live.py
@@ -1,0 +1,549 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+from datetime import datetime, timedelta
+from pathlib import Path
+from time import time
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import httpx
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import JSONResponse
+
+router = APIRouter()
+
+_KST = ZoneInfo("Asia/Seoul")
+_CODE_RE = re.compile(r"^[0-9A-Z]{1,10}$")
+_NAVER_HEADERS = {
+    "Accept": "application/json, text/plain, */*",
+    "Accept-Language": "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7",
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125 Safari/537.36",
+}
+_KIS_BASE = os.environ.get("DARTLAB_KIS_BASE") or os.environ.get("KIS_BASE") or "https://openapi.koreainvestment.com:9443"
+_KIS_APP_KEY_PATH = Path(os.environ.get("DARTLAB_KIS_APP_KEY_PATH") or os.environ.get("KIS_APP_KEY_PATH") or "~/.config/kis/app_key").expanduser()
+_KIS_APP_SECRET_PATH = Path(os.environ.get("DARTLAB_KIS_APP_SECRET_PATH") or os.environ.get("KIS_APP_SECRET_PATH") or "~/.config/kis/app_secret").expanduser()
+_KIS_TOKEN_CACHE = Path(os.environ.get("DARTLAB_KIS_TOKEN_CACHE") or os.environ.get("KIS_TOKEN_CACHE") or "~/.cache/dartlab/kis_access_token.json").expanduser()
+_KIS_QUOTE_TR_ID = os.environ.get("DARTLAB_KIS_QUOTE_TR_ID") or os.environ.get("KIS_TR_ID") or "FHKST01010100"
+_KIS_MINUTE_TR_ID = os.environ.get("DARTLAB_KIS_MINUTE_TR_ID") or "FHKST03010200"
+_KIS_TOKEN_GRACE_SEC = int(os.environ.get("DARTLAB_KIS_TOKEN_TTL_GRACE_SEC") or os.environ.get("KIS_TOKEN_TTL_GRACE_SEC") or "300")
+_KIS_QUOTE_INTERVAL_MS = max(500, int(os.environ.get("DARTLAB_KIS_QUOTE_INTERVAL_MS") or "500"))
+_KIS_QUOTE_CACHE_MS = max(250, int(os.environ.get("DARTLAB_KIS_QUOTE_CACHE_MS") or "500"))
+_KIS_MINUTE_CACHE_MS = max(1000, int(os.environ.get("DARTLAB_KIS_MINUTE_CACHE_MS") or "5000"))
+_KIS_MINUTE_MAX_BARS = max(120, int(os.environ.get("DARTLAB_KIS_MINUTE_MAX_BARS") or "450"))
+
+_kis_token_lock = asyncio.Lock()
+_kis_quote_cache: dict[str, tuple[float, dict[str, Any]]] = {}
+_kis_minute_cache: dict[str, tuple[float, list[dict[str, Any]]]] = {}
+
+
+def _json(data: Any, *, cache_control: str = "no-store") -> JSONResponse:
+    return JSONResponse(data, headers={"Cache-Control": cache_control})
+
+
+def _num(value: Any) -> float | None:
+    if isinstance(value, (int, float)):
+        n = float(value)
+        return n if n == n and n not in (float("inf"), float("-inf")) else None
+    if value is None:
+        return None
+    text = str(value).replace(",", "").replace("%", "").replace(" ", "").replace("\u2212", "-")
+    if not text:
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def _int(value: Any) -> int | None:
+    n = _num(value)
+    return int(n) if n is not None else None
+
+
+def _normalize_code(code: str) -> str:
+    c = re.sub(r"[^0-9A-Za-z]", "", code or "").upper()
+    if not c or not _CODE_RE.match(c):
+        raise HTTPException(status_code=400, detail="invalid_code")
+    return c
+
+
+def _market_label(status: str | None) -> str:
+    if status == "OPEN":
+        return "장중"
+    if status == "CLOSE":
+        return "마감"
+    if status == "PREPARE":
+        return "개장 준비"
+    return status or "확인 중"
+
+
+def _kis_available() -> bool:
+    disabled = os.environ.get("DARTLAB_KIS_DISABLE", "").strip().lower() in {"1", "true", "yes"}
+    return not disabled and _KIS_APP_KEY_PATH.is_file() and _KIS_APP_SECRET_PATH.is_file()
+
+
+def _read_secret(path: Path) -> str:
+    return path.read_text(encoding="utf-8").strip()
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _save_json_private(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass
+
+
+def _token_expires_at(payload: dict[str, Any]) -> int | None:
+    raw = payload.get("expires_at")
+    if isinstance(raw, (int, float)):
+        return int(raw)
+    if isinstance(raw, str) and raw.isdigit():
+        return int(raw)
+
+    text = str(payload.get("access_token_token_expired") or "").strip()
+    if text:
+        for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S"):
+            try:
+                return int(datetime.strptime(text[:19], fmt).replace(tzinfo=_KST).timestamp())
+            except ValueError:
+                continue
+    return None
+
+
+def _cached_kis_token() -> str | None:
+    payload = _load_json(_KIS_TOKEN_CACHE)
+    if not payload:
+        return None
+    token = str(payload.get("access_token") or "").strip()
+    expires_at = _token_expires_at(payload)
+    if token and expires_at and expires_at - int(time()) > _KIS_TOKEN_GRACE_SEC:
+        return token
+    return None
+
+
+async def _issue_kis_token(client: httpx.AsyncClient, app_key: str, app_secret: str) -> str:
+    resp = await client.post(
+        f"{_KIS_BASE.rstrip('/')}/oauth2/tokenP",
+        json={"grant_type": "client_credentials", "appkey": app_key, "appsecret": app_secret},
+        headers={"content-type": "application/json; charset=utf-8"},
+    )
+    body = resp.json()
+    token = str(body.get("access_token") or "").strip()
+    if not resp.is_success or not token:
+        msg = body.get("msg_cd") or body.get("error_code") or body.get("error") or resp.status_code
+        raise RuntimeError(f"kis_token_failed:{msg}")
+
+    issued_at = int(time())
+    expires_in = int(_num(body.get("expires_in")) or 86400)
+    payload = {
+        "access_token": token,
+        "token_type": body.get("token_type") or "Bearer",
+        "issued_at": issued_at,
+        "expires_at": issued_at + max(1, min(expires_in, 86400)),
+        "expires_in": expires_in,
+    }
+    _save_json_private(_KIS_TOKEN_CACHE, payload)
+    return token
+
+
+async def _kis_token(client: httpx.AsyncClient) -> str:
+    cached = _cached_kis_token()
+    if cached:
+        return cached
+
+    async with _kis_token_lock:
+        cached = _cached_kis_token()
+        if cached:
+            return cached
+        return await _issue_kis_token(client, _read_secret(_KIS_APP_KEY_PATH), _read_secret(_KIS_APP_SECRET_PATH))
+
+
+def _market_status_now() -> tuple[str, str, bool]:
+    now = datetime.now(_KST)
+    minutes = now.hour * 60 + now.minute
+    if now.weekday() >= 5:
+        return ("CLOSE", "휴장", False)
+    if 9 * 60 <= minutes <= 15 * 60 + 30:
+        return ("OPEN", "장중", True)
+    if 8 * 60 <= minutes < 9 * 60:
+        return ("PREPARE", "개장 준비", False)
+    return ("CLOSE", "마감", False)
+
+
+def _date_candidates(days: int = 8) -> list[str]:
+    today = datetime.now(_KST).date()
+    return [(today - timedelta(days=i)).strftime("%Y%m%d") for i in range(days)]
+
+
+def _local_dt(value: Any) -> datetime | None:
+    digits = re.sub(r"\D", "", str(value or ""))
+    if len(digits) < 12:
+        return None
+    if len(digits) == 12:
+        digits += "00"
+    try:
+        return datetime.strptime(digits[:14], "%Y%m%d%H%M%S").replace(tzinfo=_KST)
+    except ValueError:
+        return None
+
+
+def _bar_from_naver(item: dict[str, Any]) -> dict[str, Any] | None:
+    dt = _local_dt(item.get("localDateTime"))
+    close = _num(item.get("currentPrice"))
+    if dt is None or close is None or close <= 0:
+        return None
+    return {
+        "t": dt.isoformat(),
+        "o": _num(item.get("openPrice")) or close,
+        "h": _num(item.get("highPrice")) or close,
+        "l": _num(item.get("lowPrice")) or close,
+        "c": close,
+        "v": _int(item.get("accumulatedTradingVolume")) or 0,
+    }
+
+
+def _kis_minute_hour_now() -> str:
+    now = datetime.now(_KST)
+    minutes = now.hour * 60 + now.minute
+    if now.weekday() < 5 and 9 * 60 <= minutes <= 15 * 60 + 30:
+        return now.strftime("%H%M%S")
+    return "153000"
+
+
+def _bar_from_kis_minute(item: dict[str, Any]) -> dict[str, Any] | None:
+    date = re.sub(r"\D", "", str(item.get("stck_bsop_date") or ""))[:8]
+    hour = re.sub(r"\D", "", str(item.get("stck_cntg_hour") or ""))[:6]
+    if len(date) != 8 or len(hour) < 4:
+        return None
+    if len(hour) == 4:
+        hour += "00"
+    try:
+        dt = datetime.strptime(date + hour[:6], "%Y%m%d%H%M%S").replace(tzinfo=_KST)
+    except ValueError:
+        return None
+
+    close = _num(item.get("stck_prpr"))
+    if close is None or close <= 0:
+        return None
+    open_ = _num(item.get("stck_oprc")) or close
+    high = _num(item.get("stck_hgpr")) or close
+    low = _num(item.get("stck_lwpr")) or close
+    return {
+        "t": dt.isoformat(),
+        "o": open_,
+        "h": max(open_, high, low, close),
+        "l": min(open_, high, low, close),
+        "c": close,
+        "v": _int(item.get("cntg_vol")) or _int(item.get("acml_vol")) or 0,
+    }
+
+
+def _aggregate_bars(bars: list[dict[str, Any]], minutes: int) -> list[dict[str, Any]]:
+    if minutes <= 1:
+        return bars
+    buckets: dict[str, list[dict[str, Any]]] = {}
+    for bar in bars:
+        dt = datetime.fromisoformat(str(bar["t"]))
+        start = dt.replace(minute=(dt.minute // minutes) * minutes, second=0, microsecond=0)
+        buckets.setdefault(start.isoformat(), []).append(bar)
+
+    out: list[dict[str, Any]] = []
+    for key in sorted(buckets):
+        group = buckets[key]
+        out.append(
+            {
+                "t": key,
+                "o": group[0]["o"],
+                "h": max(float(x["h"]) for x in group),
+                "l": min(float(x["l"]) for x in group),
+                "c": group[-1]["c"],
+                "v": sum(int(x.get("v") or 0) for x in group),
+            }
+        )
+    return out
+
+
+async def _get_json(url: str, *, timeout: float = 5.0) -> Any:
+    async with httpx.AsyncClient(headers=_NAVER_HEADERS, timeout=timeout, follow_redirects=True) as client:
+        resp = await client.get(url)
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def _naver_quote_payload(stock_code: str) -> dict[str, Any]:
+    url = f"https://polling.finance.naver.com/api/realtime/domestic/stock/{stock_code}"
+    data = await _get_json(url, timeout=5.0)
+
+    item = (data.get("datas") or [None])[0] if isinstance(data, dict) else None
+    if not isinstance(item, dict):
+        raise HTTPException(status_code=404, detail="quote_not_found")
+
+    price = _num(item.get("closePriceRaw")) or _num(item.get("closePrice"))
+    change = _num(item.get("compareToPreviousClosePriceRaw")) or _num(item.get("compareToPreviousClosePrice"))
+    change_rate = _num(item.get("fluctuationsRatioRaw")) or _num(item.get("fluctuationsRatio"))
+    if price is None or change is None or change_rate is None:
+        raise HTTPException(status_code=502, detail="quote_parse_failed")
+
+    exchange = item.get("stockExchangeType") or {}
+    market_status = str(item.get("marketStatus") or "")
+    delay_time = _num(exchange.get("delayTime")) if isinstance(exchange, dict) else None
+    payload = {
+        "code": stock_code,
+        "name": item.get("stockName") or stock_code,
+        "provider": "naver",
+        "currency": "KRW",
+        "price": price,
+        "changeAmount": change,
+        "changeRate": change_rate,
+        "open": _num(item.get("openPriceRaw")) or _num(item.get("openPrice")),
+        "high": _num(item.get("highPriceRaw")) or _num(item.get("highPrice")),
+        "low": _num(item.get("lowPriceRaw")) or _num(item.get("lowPrice")),
+        "volume": _int(item.get("accumulatedTradingVolumeRaw")) or _int(item.get("accumulatedTradingVolume")),
+        "tradedValue": _int(item.get("accumulatedTradingValueRaw")),
+        "marketCap": _int(item.get("marketValueFullRaw")) or _int(item.get("marketValueFull")),
+        "marketStatus": market_status,
+        "marketStatusLabel": _market_label(market_status),
+        "isLive": delay_time == 0 and market_status == "OPEN",
+        "refreshIntervalMs": max(1000, _int(data.get("pollingInterval")) or 7000),
+        "tradedAt": item.get("localTradedAt") or datetime.now(_KST).isoformat(),
+        "updatedAt": datetime.now(_KST).isoformat(),
+    }
+    return payload
+
+
+async def _kis_quote_payload(stock_code: str) -> dict[str, Any]:
+    now_ms = time() * 1000
+    cached = _kis_quote_cache.get(stock_code)
+    if cached and now_ms - cached[0] < _KIS_QUOTE_CACHE_MS:
+        return {**cached[1], "cached": True}
+
+    app_key = _read_secret(_KIS_APP_KEY_PATH)
+    app_secret = _read_secret(_KIS_APP_SECRET_PATH)
+    params = {"FID_COND_MRKT_DIV_CODE": "J", "FID_INPUT_ISCD": stock_code}
+    async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
+        token = await _kis_token(client)
+        resp = await client.get(
+            f"{_KIS_BASE.rstrip('/')}/uapi/domestic-stock/v1/quotations/inquire-price",
+            params=params,
+            headers={
+                "content-type": "application/json; charset=utf-8",
+                "authorization": f"Bearer {token}",
+                "appkey": app_key,
+                "appsecret": app_secret,
+                "tr_id": _KIS_QUOTE_TR_ID,
+                "custtype": "P",
+            },
+        )
+        body = resp.json()
+
+    output = body.get("output") if isinstance(body, dict) else None
+    if not resp.is_success or not isinstance(output, dict) or body.get("rt_cd") not in (None, "0"):
+        msg = body.get("msg_cd") if isinstance(body, dict) else resp.status_code
+        raise RuntimeError(f"kis_quote_failed:{msg}")
+
+    price = _num(output.get("stck_prpr"))
+    change = _num(output.get("prdy_vrss"))
+    change_rate = _num(output.get("prdy_ctrt"))
+    if price is None or change is None or change_rate is None:
+        raise RuntimeError("kis_quote_parse_failed")
+
+    market_status, market_status_label, is_live = _market_status_now()
+    payload = {
+        "code": stock_code,
+        "name": output.get("hts_kor_isnm") or stock_code,
+        "provider": "kis",
+        "currency": "KRW",
+        "price": price,
+        "changeAmount": change,
+        "changeRate": change_rate,
+        "open": _num(output.get("stck_oprc")),
+        "high": _num(output.get("stck_hgpr")),
+        "low": _num(output.get("stck_lwpr")),
+        "volume": _int(output.get("acml_vol")),
+        "tradedValue": _int(output.get("acml_tr_pbmn")),
+        "marketCap": _int(output.get("hts_avls")),
+        "marketStatus": market_status,
+        "marketStatusLabel": market_status_label,
+        "isLive": is_live,
+        "refreshIntervalMs": _KIS_QUOTE_INTERVAL_MS,
+        "tradedAt": datetime.now(_KST).isoformat(),
+        "updatedAt": datetime.now(_KST).isoformat(),
+    }
+    _kis_quote_cache[stock_code] = (now_ms, payload)
+    return payload
+
+
+async def _kis_minute_1m_bars(stock_code: str) -> list[dict[str, Any]]:
+    now_ms = time() * 1000
+    cached = _kis_minute_cache.get(stock_code)
+    if cached and now_ms - cached[0] < _KIS_MINUTE_CACHE_MS:
+        return cached[1]
+
+    app_key = _read_secret(_KIS_APP_KEY_PATH)
+    app_secret = _read_secret(_KIS_APP_SECRET_PATH)
+    headers_base = {
+        "content-type": "application/json; charset=utf-8",
+        "appkey": app_key,
+        "appsecret": app_secret,
+        "tr_id": _KIS_MINUTE_TR_ID,
+        "custtype": "P",
+    }
+    seen: dict[str, dict[str, Any]] = {}
+    basis_date: str | None = None
+    hour = _kis_minute_hour_now()
+
+    async with httpx.AsyncClient(timeout=7.0, follow_redirects=True) as client:
+        token = await _kis_token(client)
+        headers = {**headers_base, "authorization": f"Bearer {token}"}
+        for _ in range(14):
+            resp = await client.get(
+                f"{_KIS_BASE.rstrip('/')}/uapi/domestic-stock/v1/quotations/inquire-time-itemchartprice",
+                params={
+                    "FID_ETC_CLS_CODE": "",
+                    "FID_COND_MRKT_DIV_CODE": "J",
+                    "FID_INPUT_ISCD": stock_code,
+                    "FID_INPUT_HOUR_1": hour,
+                    "FID_PW_DATA_INCU_YN": "Y",
+                },
+                headers=headers,
+            )
+            body = resp.json()
+            if not resp.is_success or not isinstance(body, dict) or body.get("rt_cd") not in (None, "0"):
+                msg = body.get("msg_cd") if isinstance(body, dict) else resp.status_code
+                raise RuntimeError(f"kis_minute_failed:{msg}")
+
+            rows = body.get("output2") or body.get("output") or []
+            if not isinstance(rows, list) or not rows:
+                break
+
+            page_all: list[dict[str, Any]] = []
+            for row in rows:
+                if not isinstance(row, dict):
+                    continue
+                bar = _bar_from_kis_minute(row)
+                if bar:
+                    page_all.append(bar)
+            if not page_all:
+                break
+            if basis_date is None:
+                basis_date = max(str(bar["t"])[:10] for bar in page_all)
+            page = [bar for bar in page_all if str(bar["t"]).startswith(basis_date)]
+            if not page:
+                break
+            for bar in page:
+                seen[str(bar["t"])] = bar
+
+            earliest = min(page, key=lambda x: str(x["t"]))
+            earliest_dt = datetime.fromisoformat(str(earliest["t"]))
+            next_dt = earliest_dt - timedelta(minutes=1)
+            if next_dt.date() != earliest_dt.date() or next_dt.hour < 9:
+                break
+            hour = next_dt.strftime("%H%M%S")
+            if len(seen) >= _KIS_MINUTE_MAX_BARS:
+                break
+            await asyncio.sleep(0.25)
+
+    all_bars = sorted(seen.values(), key=lambda x: str(x["t"]))
+    if not all_bars:
+        raise RuntimeError("kis_minute_empty")
+    latest_date = basis_date or max(str(bar["t"])[:10] for bar in all_bars)
+    bars = [bar for bar in all_bars if str(bar["t"]).startswith(latest_date)][-_KIS_MINUTE_MAX_BARS:]
+    if len(bars) < 2:
+        raise RuntimeError("kis_minute_empty")
+    _kis_minute_cache[stock_code] = (now_ms, bars)
+    return bars
+
+
+async def _kis_minute_payload(stock_code: str, timeframe: str, minutes: int) -> dict[str, Any]:
+    bars_1m = await _kis_minute_1m_bars(stock_code)
+    bars = _aggregate_bars(bars_1m, minutes)
+    latest = bars[-1]["t"]
+    basis_date = str(latest)[:10]
+    return {
+        "code": stock_code,
+        "provider": "kis",
+        "currency": "KRW",
+        "basisDate": basis_date,
+        "isFallbackDate": basis_date != datetime.now(_KST).strftime("%Y-%m-%d"),
+        "timeframe": timeframe,
+        "bars": bars,
+        "updatedAt": datetime.now(_KST).isoformat(),
+    }
+
+
+@router.get("/api/dartlab/live/quote")
+async def live_quote(code: str = Query(..., min_length=1)) -> JSONResponse:
+    stock_code = _normalize_code(code)
+    if _kis_available():
+        try:
+            return _json(await _kis_quote_payload(stock_code))
+        except (httpx.HTTPError, OSError, RuntimeError, ValueError):
+            pass
+
+    try:
+        return _json(await _naver_quote_payload(stock_code))
+    except (httpx.HTTPError, ValueError) as exc:
+        raise HTTPException(status_code=502, detail=f"quote_failed: {exc}") from exc
+
+
+@router.get("/api/dartlab/live/minute")
+async def live_minute(
+    code: str = Query(..., min_length=1),
+    timeframe: str = Query("1m", pattern="^(1m|3m|5m)$"),
+) -> JSONResponse:
+    stock_code = _normalize_code(code)
+    minutes = int(timeframe.removesuffix("m"))
+    last_error: Exception | None = None
+
+    if _kis_available():
+        try:
+            return _json(await _kis_minute_payload(stock_code, timeframe, minutes), cache_control="no-store")
+        except (httpx.HTTPError, OSError, RuntimeError, ValueError) as exc:
+            last_error = exc
+
+    for idx, date in enumerate(_date_candidates()):
+        url = (
+            "https://api.stock.naver.com/chart/domestic/item/"
+            f"{stock_code}/minute?startDateTime={date}0900&endDateTime={date}1530"
+        )
+        try:
+            data = await _get_json(url, timeout=7.0)
+            if not isinstance(data, list):
+                raise ValueError("minute_payload_not_list")
+            bars = [_bar_from_naver(item) for item in data if isinstance(item, dict)]
+            bars = [bar for bar in bars if bar is not None]
+            if len(bars) < 2:
+                raise ValueError("minute_bars_too_short")
+            bars.sort(key=lambda x: str(x["t"]))
+            return _json(
+                {
+                    "code": stock_code,
+                    "provider": "naver",
+                    "currency": "KRW",
+                    "basisDate": f"{date[:4]}-{date[4:6]}-{date[6:]}",
+                    "isFallbackDate": idx > 0,
+                    "timeframe": timeframe,
+                    "bars": _aggregate_bars(bars, minutes),
+                    "updatedAt": datetime.now(_KST).isoformat(),
+                },
+                cache_control="no-store",
+            )
+        except (httpx.HTTPError, ValueError) as exc:
+            last_error = exc
+            continue
+
+    raise HTTPException(status_code=502, detail=f"minute_failed: {last_error}")

--- a/ui/packages/surfaces/src/terminal/charts/ChartRibbon.svelte
+++ b/ui/packages/surfaces/src/terminal/charts/ChartRibbon.svelte
@@ -20,7 +20,7 @@
 		name: string;
 		code: string;
 		// 표시 시계열 기준 (리플레이 절단 반영 — PriceChart.ribbonInfo): 현재가·전일대비·기준일·52주
-		info: { last: number; prev: number | null; date: string; hi: number; lo: number } | null;
+		info: { last: number; prev: number | null; date: string; hi: number; lo: number; live?: boolean; provider?: string; status?: string } | null;
 		notice?: string | null; // 자동 tf 상향·백필 진행 등 상태 피드백 1줄
 		peers?: { code: string; name: string }[];
 		cmpRows?: { name: string; code: string; r: (number | null)[] }[]; // VS 팝오버 기간 수익률 (1M/3M/6M/1Y)
@@ -37,9 +37,10 @@
 	const T = (kr: string, en: string) => (lang === 'en' ? en : kr);
 	const styleShown = $derived(indexLine ? 'area' : ctl.candleStyle); // US 지수면 'area'(라인) 강조 — disabled 세그먼트 정합
 	const fmtN = (v: number) => v.toLocaleString('en-US', { maximumFractionDigits: 0 });
-	const fmtD = (t: string) => `${t.slice(0, 4)}-${t.slice(4, 6)}-${t.slice(6, 8)}`;
+	const fmtD = (t: string) => /^\d{8}$/.test(t) ? `${t.slice(0, 4)}-${t.slice(4, 6)}-${t.slice(6, 8)}` : t.slice(0, 16).replace('T', ' ');
 	const chg = $derived(info && info.prev ? ((info.last / info.prev) - 1) * 100 : null);
 	const pos52 = $derived(info && info.hi > info.lo ? Math.max(0, Math.min(100, ((info.last - info.lo) / (info.hi - info.lo)) * 100)) : null);
+	const quoteSource = $derived(!info?.live ? 'EOD' : info.provider === 'kis' ? 'KIS' : info.provider === 'naver' ? 'NAVER' : 'LIVE');
 	const CMP_RET_LBL = ['1M', '3M', '6M', '1Y'];
 	let pop = $state<string>('none'); // 'econ' | 'ovAdd' | 'subAdd' | 'bt' | 'vs' | 'tmpl' | `edit:${지표명}`
 	const offOverlays = $derived(OVERLAY_ALL.filter((o) => !ctl.overlays.includes(o)));
@@ -67,7 +68,7 @@
 			{#if info}
 				<span class="mono crLast">{fmtN(info.last)}</span>
 				{#if chg != null}<span class={'mono ' + (chg >= 0 ? 'tUp' : 'tDn')}>{chg >= 0 ? '+' : ''}{chg.toFixed(1)}%{info.prev != null ? ` (${chg >= 0 ? '+' : '−'}${fmtN(Math.abs(info.last - info.prev))})` : ''}</span>{/if}
-				<span class="crEod mono" title={T('일별 종가 기준(EOD) — 이 차트의 마지막 데이터 일자', 'end-of-day — last data date')}>EOD {fmtD(info.date)}</span>
+				<span class="crEod mono" title={info.live ? T(`웹 현재가 · ${info.status ?? '확인 중'}`, `web quote · ${info.status ?? 'unknown'}`) : T('일별 종가 기준(EOD) — 이 차트의 마지막 데이터 일자', 'end-of-day — last data date')}>{quoteSource} {fmtD(info.date)}</span>
 				{#if pos52 != null}
 					<span class="cr52" title={T(`52주 위치 ${pos52.toFixed(0)}% (저 ${fmtN(info.lo)} ~ 고 ${fmtN(info.hi)})`, `52w position ${pos52.toFixed(0)}%`)}>
 						<i class="cr52Lbl">52W</i><span class="cr52Track"><span class="cr52Now" style={`left:${pos52}%`}></span></span>

--- a/ui/packages/surfaces/src/terminal/charts/PriceChart.svelte
+++ b/ui/packages/surfaces/src/terminal/charts/PriceChart.svelte
@@ -16,7 +16,7 @@
 	import { registerBtIndicators, buildBtExtend, applyBt, clearBt } from './btLayer';
 	import { registerEconIndicator, ECON_INDICATOR, type EconExtend } from './econOverlay';
 	import { registerExtraIndicators } from './extraIndicators';
-	import { type ChartCtl, PERIOD_N, TF_DIV, type CandleStyle, type IndexControl, type OverlayKey, type SubKey, type TfKey } from './chartState.svelte';
+	import { type ChartCtl, PERIOD_N, TF_DIV, isMinuteTf, type CandleStyle, type IndexControl, type MinuteTfKey, type OverlayKey, type PeriodKey, type SubKey, type TfKey } from './chartState.svelte';
 	import { loadDraws, saveDraws, type SavedDraw } from './drawStore';
 	import { publishView } from './seriesBus';
 	import { registerWorkOverlays, MEASURE_NAME, TEXT_NAME } from './avwapOverlay';
@@ -28,6 +28,7 @@
 	import ChartRibbon from './ChartRibbon.svelte';
 	import DrawToolbar from './DrawToolbar.svelte';
 	import BtChip from './BtChip.svelte';
+	import { fetchLiveQuote, fetchMinuteBars, type LiveQuote, type MinuteBar } from '../lib/livePrice';
 
 	interface Props {
 		candles: Candle[]; // 초기(현재+직전 연도)
@@ -108,6 +109,9 @@
 	let dataRev = $state(0);
 	let dataRevSeq = 0;
 	const bumpDataRev = () => (dataRev = ++dataRevSeq);
+	let minuteRev = $state(0);
+	let minuteRevSeq = 0;
+	const bumpMinuteRev = () => (minuteRev = ++minuteRevSeq);
 	let econOn = false; // ECON indicator 생성 여부 (비반응)
 	let econToken = 0; // stale async 가드
 	let cmpOn = false; // 종목비교(CMP) indicator 생성 여부 (비반응)
@@ -121,6 +125,7 @@
 	let bandIds: string[] = [];
 	let eventIds: string[] = [];
 	let refIds: string[] = [];
+	let liveQuoteLineIds: string[] = [];
 	// 드로잉 — drawMap = 완성 드로잉 id→직렬화 (localStorage 영속 SSOT). pending = 진행중(ESC 취소 대상).
 	const drawMap = new Map<string, SavedDraw>();
 	let pendingDrawId: string | null = null;
@@ -128,6 +133,16 @@
 	// load-more 상태 (비반응 — 콜백이 읽음). oldestYear↔newestYear = 현재 로드된 이력 범위.
 	// viewLen = 현재 tf 로 차트에 적용된 봉 수 (주/월 집계 후 길이 — applySpacing 기준).
 	const hist = { code: '', oldestYear: 9999, newestYear: 0, loading: false, viewLen: 0 };
+	const MINUTE_REFRESH_MS = 15_000; // 분봉 전체 재조회 — 새 분 형성·거래량 보정
+	const QUOTE_REFRESH_MS = 500; // 선택된 단일 종목 현재가 — 마지막 분봉 close 를 0.5초 단위로 보정
+	const MINUTE_PERIOD_N: Record<PeriodKey, number> = { '1M': 60, '3M': 120, '6M': 180, '1Y': 240, '3Y': 360, MAX: 100000 };
+	let minuteCandles = $state<Candle[]>([]);
+	let minuteFor = $state<{ code: string; tf: MinuteTfKey } | null>(null);
+	let minuteProvider = $state<string | null>(null);
+	let liveQuote = $state<LiveQuote | null>(null);
+	let liveQuoteRev = $state(0);
+	let liveQuoteRevSeq = 0;
+	const bumpLiveQuoteRev = () => (liveQuoteRev = ++liveQuoteRevSeq);
 	let appliedTf: TfKey = 'D'; // tf effect 의 mount 중복 재적용 차단용 비반응 스냅샷
 	let appliedStyle: CandleStyle = ctl.candleStyle; // HA ↔ 비HA 전환만 데이터 재적용 (스냅샷 가드)
 	// 바 리플레이 — replayCutT = 현재 리플레이 봉 라벨(YYYYMMDD, 비반응). displaySeries 가 이 날짜까지
@@ -135,7 +150,13 @@
 	let replayCutT: string | null = null;
 	let appliedReplay = { on: false, idx: -1 }; // replay effect 중복 재적용 차단 스냅샷
 
-	const toMs = (t: string) => Date.UTC(+t.slice(0, 4), +t.slice(4, 6) - 1, +t.slice(6, 8));
+	const toMs = (t: string) => {
+		if (/^\d{8}$/.test(t)) return Date.UTC(+t.slice(0, 4), +t.slice(4, 6) - 1, +t.slice(6, 8));
+		const m = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?/.exec(t);
+		if (m) return Date.UTC(+m[1], +m[2] - 1, +m[3], +m[4], +m[5], +(m[6] ?? 0));
+		const ms = Date.parse(t);
+		return Number.isFinite(ms) ? ms : 0;
+	};
 	// x축 날짜 라벨을 한국식 간단 표기로 압축 — 라이브러리 기본(YYYY-MM·MM-DD·YYYY)을 YY.MM·MM.DD·YYYY 로.
 	// registerXAxis 가 이미 계산된 ticks 의 text 만 치환(틱 산출·간격 로직은 라이브러리 그대로 — 회귀 0).
 	function compactAxisText(s: string): string {
@@ -148,6 +169,45 @@
 	// turnover 는 억 단위 — {turnover} 플레이스홀더가 콤마만 붙이고 축약을 안 해 원 단위면
 	// "446,546,135,655" 생짜 노출 (TVAL 페인·매물대 가중치도 동일 단위 공유, 상대값이라 무영향)
 	const toK = (c: Candle) => ({ timestamp: toMs(c.t), open: c.o, high: c.h, low: c.l, close: c.c, volume: c.v, turnover: c.tv != null ? c.tv / 1e8 : undefined });
+
+	const minuteLabel = (tf: MinuteTfKey, lg: Lang = lang) =>
+		tf === '1m' ? (lg === 'en' ? '1m' : '1분봉')
+		: tf === '3m' ? (lg === 'en' ? '3m' : '3분봉')
+		: lg === 'en' ? '5m' : '5분봉';
+	const minuteSourceLabel = (provider: string | null, lg: Lang = lang) =>
+		provider === 'kis'
+			? (lg === 'en' ? 'Korea Investment OpenAPI' : '한국투자증권 OpenAPI')
+			: provider === 'naver'
+				? (lg === 'en' ? 'Naver Finance' : '네이버증권')
+				: (lg === 'en' ? 'live quote API' : '실시간 시세 API');
+	function minuteBarsToCandles(bars: MinuteBar[]): Candle[] {
+		const out: Candle[] = [];
+		let prevC: number | null = null;
+		for (const b of [...bars].sort((a, z) => a.t.localeCompare(z.t))) {
+			const o = Number(b.o), h = Number(b.h), l = Number(b.l), c = Number(b.c), v = Number(b.v);
+			if (![o, h, l, c, v].every((x) => Number.isFinite(x)) || c <= 0) continue;
+			out.push({ t: b.t, o, h: Math.max(o, h, l, c), l: Math.min(o, h, l, c), c, v, r: prevC && prevC > 0 ? (c / prevC - 1) * 100 : null });
+			prevC = c;
+		}
+		return out;
+	}
+	function minuteBucketIso(tf: MinuteTfKey, raw?: string): string {
+		const mins = Number(tf.slice(0, -1)) || 1;
+		const m = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/.exec(raw || '');
+		let y: number, mo: number, d: number, h: number, mi: number;
+		if (m) {
+			y = +m[1]; mo = +m[2]; d = +m[3]; h = +m[4]; mi = +m[5];
+		} else {
+			const now = new Date();
+			y = now.getFullYear(); mo = now.getMonth() + 1; d = now.getDate(); h = now.getHours(); mi = now.getMinutes();
+		}
+		mi = Math.floor(mi / mins) * mins;
+		const p = (n: number) => String(n).padStart(2, '0');
+		return `${y}-${p(mo)}-${p(d)}T${p(h)}:${p(mi)}:00+09:00`;
+	}
+	function periodBars(tf: TfKey, p: PeriodKey, len: number): number {
+		return Math.min(isMinuteTf(tf) ? (MINUTE_PERIOD_N[p] ?? len) : Math.ceil((PERIOD_N[p] ?? len) / TF_DIV[tf]), len);
+	}
 
 	// 공시 레일(02 §4) — disclosures(날짜 그룹) 각 날짜를 convertToPixel 로 x 픽셀화해 x축 날짜라벨 "아래" 전용 띠에 dot 배치.
 	// 캔들 고가 텍스트 annotation(폭주·가격 차폐, §2.2 금지) 폐기. 레일 띠 = 캔버스가 끝나는 chartWrap 하단 padding 영역
@@ -222,13 +282,20 @@
 	});
 	// 리본 Row1 정보 — 표시 시계열(리플레이 절단·수정주가 반영) 기준이라 리플레이 중에도 정직.
 	// dataRev = reapply 동행 신호 (displaySeries 내부 untrack 읽기를 대신 깨운다).
-	const ribbonInfo = $derived.by<{ last: number; prev: number | null; date: string; hi: number; lo: number } | null>(() => {
+	const ribbonInfo = $derived.by<{ last: number; prev: number | null; date: string; hi: number; lo: number; live?: boolean; provider?: string; status?: string } | null>(() => {
 		void dataRev;
-		if (!candles.length) return null;
-		const s = displaySeries();
+		void minuteRev;
+		void liveQuoteRev;
+		const tfv = ctl.tf;
+		if (!candles.length && !minuteCandles.length) return null;
+		const s = isMinuteTf(tfv) ? chartSourceSeries(tfv) : displaySeries();
+		const q = subject === 'price' && !ctl.replay.on && liveQuote?.code === code ? liveQuote : null;
 		if (!s.length) {
 			const n = candles.length;
-			return { last: candles[n - 1].c, prev: n >= 2 ? candles[n - 2].c : null, date: candles[n - 1].t, hi: candles[n - 1].h, lo: candles[n - 1].l };
+			const fallback = { last: candles[n - 1].c, prev: n >= 2 ? candles[n - 2].c : null, date: candles[n - 1].t, hi: candles[n - 1].h, lo: candles[n - 1].l };
+			if (!q) return fallback;
+			const prev = Number.isFinite(q.changeAmount) ? q.price - q.changeAmount : fallback.prev;
+			return { ...fallback, last: q.price, prev, date: q.tradedAt || q.updatedAt, hi: Math.max(fallback.hi, q.high ?? q.price, q.price), lo: Math.min(fallback.lo, q.low ?? q.price, q.price), live: true, provider: q.provider, status: q.marketStatusLabel || q.marketStatus };
 		}
 		const lastK = s[s.length - 1];
 		const win = s.slice(-252);
@@ -238,7 +305,9 @@
 			if (k.h > hi) hi = k.h;
 			if (k.l < lo) lo = k.l;
 		}
-		return { last: lastK.c, prev: s.length >= 2 ? s[s.length - 2].c : null, date: lastK.t, hi, lo };
+		if (!q) return { last: lastK.c, prev: s.length >= 2 ? s[s.length - 2].c : null, date: lastK.t, hi, lo };
+		const prev = Number.isFinite(q.changeAmount) ? q.price - q.changeAmount : s.length >= 2 ? s[s.length - 2].c : null;
+		return { last: q.price, prev, date: q.tradedAt || q.updatedAt, hi: Math.max(hi, q.high ?? q.price, q.price), lo: Math.min(lo, q.low ?? q.price, q.price), live: true, provider: q.provider, status: q.marketStatusLabel || q.marketStatus };
 	});
 	// 상태 피드백 1줄 — 과거 백필 진행 동작을 리본에 노출 (침묵 로딩 = 버그처럼 보임 방지)
 	let notice = $state<string | null>(null);
@@ -361,6 +430,12 @@
 				const p = (n: number) => String(n).padStart(2, '0');
 				return `${d.getUTCFullYear()}-${p(d.getUTCMonth() + 1)}-${p(d.getUTCDate())}`;
 			};
+			const fmtChartDate = (ts: number) => {
+				const d = new Date(ts);
+				const p = (n: number) => String(n).padStart(2, '0');
+				const ymd = `${d.getUTCFullYear()}-${p(d.getUTCMonth() + 1)}-${p(d.getUTCDate())}`;
+				return untrack(() => isMinuteTf(ctl.tf)) ? `${ymd} ${p(d.getUTCHours())}:${p(d.getUTCMinutes())}` : ymd;
+			};
 			// 큰 수 표기 — 라이브러리 기본 K/M/B(서양식) 대신 만·억·조. 거래량(주)·거래대금(원)
 			// 축 라벨·툴팁 공통. 자릿수 규칙 고정: 조·억 = 소수 2자리, 만 = 정수, 만 미만 = 정수 콤마.
 			const fmtBigKr = (value: string | number): string => {
@@ -375,7 +450,7 @@
 			try {
 				local.setCustomApi({
 					formatDate: (dtf: unknown, ts: number, format: string, type: number) => {
-						if (type === 0 || type === 1) return fmtYmd(ts);
+						if (type === 0 || type === 1) return fmtChartDate(ts);
 						try { return mod.utils.formatDate(dtf, ts, format); } catch { return fmtYmd(ts); }
 					},
 					formatBigNumber: fmtBigKr
@@ -439,6 +514,11 @@
 		return untrack(() => ctl.adj) ? adjustCandles(base) : base;
 	}
 
+	function chartSourceSeries(tfv: TfKey): Candle[] {
+		if (isMinuteTf(tfv) && subject === 'price') return minuteFor?.code === code && minuteFor.tf === tfv ? minuteCandles : [];
+		return fullSeries();
+	}
+
 	// 표시 시계열 (BT·기준선·이벤트 마커 공용) — 리플레이 중엔 현재 봉 날짜까지 절단.
 	// 절단 덕에 dataRev 의존 effect(BT·52주 기준선)가 그 시점까지 데이터만으로 정직하게 재계산된다.
 	function displaySeries(): Candle[] {
@@ -453,13 +533,15 @@
 	// 리플레이 ON 이면 idx 봉까지 절단, 하이킨아시면 적용 직전 변환(버스·BT 는 원본 가격 유지).
 	function reapply(c: any) {
 		const tfv = untrack(() => ctl.tf);
-		const base = fullSeries();
+		const base = chartSourceSeries(tfv);
 		if (!base.length) return;
-		// 가용 데이터 범위 publish — 검증 구간 날짜 입력 bound·기본 전체창(StrategyDock). 동일값 가드로 재실행 루프 0.
-		const loT = base[0].t, hiT = base[base.length - 1].t;
-		if (ctl.dataFromT !== loT) ctl.dataFromT = loT;
-		if (ctl.dataToT !== hiT) ctl.dataToT = hiT;
-		let view = tfv === 'D' ? base : aggregateCandles(base, tfv);
+		if (!isMinuteTf(tfv)) {
+			// 가용 데이터 범위 publish — 검증 구간 날짜 입력 bound·기본 전체창(StrategyDock). 동일값 가드로 재실행 루프 0.
+			const loT = base[0].t, hiT = base[base.length - 1].t;
+			if (ctl.dataFromT !== loT) ctl.dataFromT = loT;
+			if (ctl.dataToT !== hiT) ctl.dataToT = hiT;
+		}
+		let view = tfv === 'D' || isMinuteTf(tfv) ? base : aggregateCandles(base, tfv);
 		hist.viewLen = view.length; // 전체 길이 (리플레이 절단 전 — applySpacing·replay len 기준)
 		// ⚠ untrack 은 콜백 안 읽기만 보호 — proxy 를 꺼내 밖에서 .on 읽으면 호출 effect 에 의존이 생긴다
 		const rp = untrack(() => ({ on: ctl.replay.on, idx: ctl.replay.idx }));
@@ -472,7 +554,8 @@
 		publishView(view, toMs); // AVWAP·측정룰러가 구독하는 표시 시계열 버스 (원본 가격)
 		const out = !indexLine && untrack(() => ctl.candleStyle) === 'ha' ? heikinAshi(view) : view;
 		c.applyNewData(out.map(toK), !rp.on && tfv === 'D' && hist.oldestYear - 1 >= KRX_MIN_YEAR);
-		bumpDataRev();
+		if (isMinuteTf(tfv)) bumpMinuteRev();
+		else bumpDataRev();
 	}
 
 	// 리플레이를 reapply 없이 종료 — 직후 자체 reapply 하는 effect(회사전환·tf·adj)용 (이중 재적용 방지).
@@ -482,6 +565,35 @@
 			ctl.replayExit();
 			appliedReplay = { on: false, idx: ctl.replay.idx };
 		});
+	}
+
+	function applyLiveQuoteToMinute(c: any, tfv: MinuteTfKey, price: number, tradedAt?: string) {
+		if (!Number.isFinite(price) || price <= 0) return;
+		const t = minuteBucketIso(tfv, tradedAt);
+		const base = minuteCandles;
+		const last = base[base.length - 1];
+		let next: Candle;
+		let out: Candle[];
+		const merge = (old: Candle): Candle => ({ ...old, c: price, h: Math.max(old.h, price), l: Math.min(old.l, price) });
+		if (last?.t === t) {
+			next = merge(last);
+			out = [...base.slice(0, -1), next];
+		} else {
+			const idx = base.findIndex((x) => x.t === t);
+			if (idx >= 0) {
+				next = merge(base[idx]);
+				out = [...base.slice(0, idx), next, ...base.slice(idx + 1)];
+			} else if (!last || last.t < t) {
+				next = { t, o: price, h: price, l: price, c: price, v: 0, r: last?.c ? (price / last.c - 1) * 100 : null };
+				out = [...base, next];
+			} else {
+				return;
+			}
+		}
+		minuteCandles = out.slice(-420);
+		hist.viewLen = minuteCandles.length;
+		try { c.updateData(toK(next)); } catch { reapply(c); }
+		bumpMinuteRev();
 	}
 
 	// ── 데이터 적용 (회사전환 = applyNewData, dispose 안 함 = 영속) ──
@@ -494,10 +606,21 @@
 		hist.newestYear = +cs[cs.length - 1].t.slice(0, 4);
 		hist.loading = false;
 		exitReplaySilently(); // 회사 전환 — 이전 회사 시점 리플레이는 무의미
-		reapply(c);
+		if (untrack(() => isMinuteTf(ctl.tf))) {
+			minuteCandles = [];
+			minuteFor = null;
+			minuteProvider = null;
+			hist.viewLen = 0;
+			try { c.applyNewData([], false); } catch { /* */ }
+			bumpMinuteRev();
+		} else {
+			reapply(c);
+		}
 		bandIds.forEach((id) => c.removeOverlay(id));
 		eventIds.forEach((id) => c.removeOverlay(id));
 		refIds.forEach((id) => c.removeOverlay(id));
+		liveQuoteLineIds.forEach((id) => c.removeOverlay(id));
+		liveQuoteLineIds = [];
 		try { c.removeOverlay({ groupId: 'draw' }); } catch { /* */ }
 		bandIds = [];
 		eventIds = [];
@@ -510,8 +633,88 @@
 		// untrack — applyPeriodFull 의 ctl.period 읽기가 본 effect 의존이 되면 기간 클릭마다
 		// 회사전환 전체(재적용+드로잉 삭제)가 재실행되고, viewLen 갱신 전 이중 tf 상향(W→M)까지 일으킨다.
 		untrack(() => applyPeriodFull(c));
-		// 주/월봉 유지 상태로 회사 전환 — 집계 정합 위해 전체 백필 (gov 전이력 회사는 no-op)
-		if (untrack(() => ctl.tf) !== 'D') void backfillTo(c, KRX_MIN_YEAR);
+		// 주/월봉 유지 상태로 회사 전환 — 집계 정합 위해 전체 백필 (분봉은 서버 분봉 API가 담당)
+		const tf0 = untrack(() => ctl.tf);
+		if (tf0 !== 'D' && !isMinuteTf(tf0)) void backfillTo(c, KRX_MIN_YEAR);
+	});
+
+	// 분봉 선택 — 기존 차트 인스턴스에 서버 실시간 분봉을 직접 적용. 별도 패널/별도 차트 없음.
+	$effect(() => {
+		const tfv = ctl.tf;
+		const c = chart;
+		const cd = code;
+		const subj = subject;
+		if (!c || subj !== 'price' || !isMinuteTf(tfv)) return;
+		let cancelled = false;
+		let busy = false;
+		const load = async (showNotice: boolean) => {
+			if (busy) return;
+			busy = true;
+			if (showNotice) {
+				notice = T(`실시간 ${minuteLabel(tfv, 'kr')} 불러오는 중 …`, `loading live ${minuteLabel(tfv, 'en')} …`);
+			}
+			try {
+				const res = await fetchMinuteBars(cd, tfv);
+				if (cancelled || chart !== c || code !== cd || ctl.tf !== tfv) return;
+				if (!res?.bars?.length) throw new Error('minute_empty');
+				minuteCandles = minuteBarsToCandles(res.bars);
+				minuteFor = { code: cd, tf: tfv };
+				minuteProvider = res.provider;
+				untrack(() => {
+					reapply(c);
+					applySpacing(c);
+				});
+			} catch {
+				if (!cancelled && showNotice) notice = T('분봉 데이터를 불러오지 못했습니다', 'minute bars unavailable');
+			} finally {
+				busy = false;
+				if (!cancelled) {
+					if (notice?.includes('불러오는 중') || notice?.includes('loading live')) notice = null;
+				}
+			}
+		};
+		void load(true);
+		const id = setInterval(() => void load(false), MINUTE_REFRESH_MS);
+		return () => {
+			cancelled = true;
+			clearInterval(id);
+		};
+	});
+
+	// 현재가 조회 — 단일 선택 종목의 웹 quote 를 리본에 반영하고, 분봉 화면이면 마지막 봉도 보정한다.
+	$effect(() => {
+		const c = chart;
+		const cd = code;
+		const subj = subject;
+		if (!c || subj !== 'price') return;
+		let cancelled = false;
+		let timer: ReturnType<typeof setTimeout> | null = null;
+		let delay = QUOTE_REFRESH_MS;
+		liveQuote = null;
+		bumpLiveQuoteRev();
+		const schedule = () => {
+			if (!cancelled) timer = setTimeout(() => void tick(), delay);
+		};
+		const tick = async () => {
+			try {
+				const q = await fetchLiveQuote(cd);
+				delay = q?.provider === 'kis'
+					? Math.max(QUOTE_REFRESH_MS, q.refreshIntervalMs ?? QUOTE_REFRESH_MS)
+					: Math.max(3000, q?.refreshIntervalMs ?? 7000);
+				if (cancelled || chart !== c || code !== cd || !q) return;
+				liveQuote = q;
+				bumpLiveQuoteRev();
+				const tfv = untrack(() => ctl.tf);
+				if (isMinuteTf(tfv)) untrack(() => applyLiveQuoteToMinute(c, tfv, q.price, q.tradedAt || q.updatedAt));
+			} finally {
+				schedule();
+			}
+		};
+		void tick();
+		return () => {
+			cancelled = true;
+			if (timer) clearTimeout(timer);
+		};
 	});
 
 	// 가시 봉 수 재배치 — 현재 tf 적용 후 봉 수(viewLen) 기준. klinecharts BarSpace 하한 = 1px:
@@ -534,7 +737,7 @@
 				return;
 			}
 		}
-		const N = Math.min(Math.ceil((PERIOD_N[ctl.period] ?? len) / TF_DIV[tfv]), len);
+		const N = periodBars(tfv, ctl.period, len);
 		const space = w / Math.max(1, N);
 		// 봉 주기는 사용자가 고른 그대로 유지한다 — 긴 기간에서 일/주봉이 1px 미만이 되어도 자동 상향(일→주→월)
 		// 하지 않는다(HTS·TradingView 관행: tf = 집계 선택일 뿐, 과거는 드래그/스크롤로 이동). 1px 미만이면 최근
@@ -570,6 +773,7 @@
 	const yearsForPeriod = (p: string): number => (p === 'MAX' ? 999 : Math.ceil((PERIOD_N[p] ?? 252) / 252) + 1);
 	function applyPeriodFull(c: any) {
 		applySpacing(c);
+		if (isMinuteTf(untrack(() => ctl.tf))) return;
 		const target = ctl.btCustomWin && ctl.btWinFrom
 			? Math.max(KRX_MIN_YEAR, +ctl.btWinFrom.slice(0, 4) - 1) // 커스텀 시작연도까지 백필(워밍업 여유 −1)
 			: ctl.period === 'MAX' ? KRX_MIN_YEAR : Math.max(KRX_MIN_YEAR, hist.newestYear - yearsForPeriod(ctl.period) + 1);
@@ -588,7 +792,21 @@
 		exitReplaySilently(); // 봉 주기 전환 — 리플레이 idx 좌표계가 깨지므로 자동 종료
 		const code0 = hist.code;
 		(async () => {
-			if (tfv !== 'D') await backfillTo(c, KRX_MIN_YEAR);
+			if (isMinuteTf(tfv)) {
+				if (minuteFor?.code !== code || minuteFor.tf !== tfv) {
+					minuteCandles = [];
+					minuteFor = null;
+					minuteProvider = null;
+					hist.viewLen = 0;
+					try { c.applyNewData([], false); } catch { /* */ }
+					bumpMinuteRev();
+				} else {
+					reapply(c);
+					applySpacing(c);
+				}
+				return;
+			}
+			if (tfv !== 'D' && !isMinuteTf(tfv)) await backfillTo(c, KRX_MIN_YEAR);
 			if (chart !== c || hist.code !== code0) return;
 			reapply(c);
 			applySpacing(c);
@@ -666,7 +884,8 @@
 	// 리플레이 진입 — 시작점 = 현재 기간 윈도 시작(최소 30봉 워밍업), 현재 tf 봉 수로 환산.
 	function enterReplay() {
 		if (!chart || !hist.viewLen) return;
-		const n = Math.ceil((PERIOD_N[ctl.period] ?? 252) / TF_DIV[ctl.tf]);
+		if (isMinuteTf(ctl.tf)) return;
+		const n = periodBars(ctl.tf, ctl.period, hist.viewLen);
 		const idx = Math.min(Math.max(30, hist.viewLen - n), hist.viewLen - 1);
 		ctl.replay = { on: true, idx, playing: false, start: idx, len: hist.viewLen };
 	}
@@ -781,6 +1000,19 @@
 		const prevC = base[base.length - 2].c;
 		const mk = (price: number, color: string) => c.createOverlay({ name: 'priceLine', points: [{ value: price }], lock: true, styles: { line: { color, style: 'dashed', size: 1 }, text: { color } } });
 		refIds = [mk(hi, 'rgba(240,97,111,0.65)'), mk(lo, 'rgba(96,165,250,0.65)'), mk(prevC, 'rgba(139,145,158,0.65)')].filter(Boolean) as string[];
+	});
+
+	// 웹 현재가 라인 — 캔들 데이터는 변경하지 않고 차트 안에서 현재 quote 위치만 표시한다.
+	$effect(() => {
+		void liveQuoteRev;
+		const c = chart;
+		const q = liveQuote;
+		liveQuoteLineIds.forEach((id) => c?.removeOverlay(id));
+		liveQuoteLineIds = [];
+		if (!c || subject !== 'price' || ctl.replay.on || q?.code !== code || !Number.isFinite(q.price) || q.price <= 0) return;
+		const color = q.changeAmount >= 0 ? 'rgba(52,211,153,0.9)' : 'rgba(240,97,111,0.9)';
+		const id = c.createOverlay({ name: 'priceLine', points: [{ value: q.price }], lock: true, styles: { line: { color, style: 'solid', size: 1 }, text: { color } } });
+		liveQuoteLineIds = id ? [id] : [];
 	});
 
 	// 실적·공시 시점 마커 → simpleAnnotation (토글, 가장 가까운 거래일 스냅).
@@ -1253,11 +1485,15 @@
 
 	const T = (kr: string, en: string) => (lang === 'en' ? en : kr);
 	// 출처 표기 SSOT — DOM 캡션과 스냅샷 띠가 같은 문자열 (공공누리 출처표시 의무)
-	const srcText = () =>
-		T('출처: 금융위원회·한국거래소 (공공데이터포털)', 'Source: FSC · KRX (data.go.kr)') +
-		(ctl.econ.length ? ' · ' + MACRO_ATTRIBUTION : '') +
-		(ctl.adj ? T(' · 수정주가', ' · adjusted') : '') +
-		(ctl.candleStyle === 'ha' ? ' · HA' : ''); // 하이킨아시 = 변형값 정직 고지
+	const srcText = () => {
+		const minute = isMinuteTf(ctl.tf);
+		return (minute
+			? T(`출처: ${minuteSourceLabel(minuteProvider, 'kr')} (분봉)`, `Source: ${minuteSourceLabel(minuteProvider, 'en')} (minute bars)`)
+			: T('출처: 금융위원회·한국거래소 (공공데이터포털)', 'Source: FSC · KRX (data.go.kr)')) +
+			(ctl.econ.length ? ' · ' + MACRO_ATTRIBUTION : '') +
+			(!minute && ctl.adj ? T(' · 수정주가', ' · adjusted') : '') +
+			(ctl.candleStyle === 'ha' ? ' · HA' : ''); // 하이킨아시 = 변형값 정직 고지
+	};
 	function snapshot() {
 		const ymd = candles.length ? candles[candles.length - 1].t : '';
 		const date = ymd ? `${ymd.slice(0, 4)}-${ymd.slice(4, 6)}-${ymd.slice(6, 8)}` : '';

--- a/ui/packages/surfaces/src/terminal/charts/chartState.svelte.ts
+++ b/ui/packages/surfaces/src/terminal/charts/chartState.svelte.ts
@@ -51,17 +51,23 @@ function subYmdMonths(ymd: string, months: number): string {
 	const p = (n: number) => String(n).padStart(2, '0');
 	return `${d.getUTCFullYear()}${p(d.getUTCMonth() + 1)}${p(d.getUTCDate())}`;
 }
-// 봉 주기 — 데이터는 일봉, 주/월/분기/년은 클라이언트 집계(aggregateCandles). TF_DIV = 거래일 환산 제수.
-// 자동 상향 체인(바스페이스 1px 미달)은 일→주→월까지만 — 분기·년은 수동 선택 전용.
-export type TfKey = 'D' | 'W' | 'M' | 'Q' | 'Y';
+// 봉 주기 — 1/3/5분은 서버 실시간 분봉, 일봉은 원본, 주/월/분기/년은 클라이언트 집계(aggregateCandles).
+// TF_DIV = 거래일 환산 제수. 분봉은 기간 칩의 "보이는 봉 수"만 따로 환산한다(PriceChart).
+export type MinuteTfKey = '1m' | '3m' | '5m';
+export type TfKey = MinuteTfKey | 'D' | 'W' | 'M' | 'Q' | 'Y';
+export const MINUTE_TFS: MinuteTfKey[] = ['1m', '3m', '5m'];
+export const isMinuteTf = (tf: TfKey): tf is MinuteTfKey => (MINUTE_TFS as readonly string[]).includes(tf);
 export const TFS: { v: TfKey; kr: string; en: string }[] = [
+	{ v: '1m', kr: '1분', en: '1m' },
+	{ v: '3m', kr: '3분', en: '3m' },
+	{ v: '5m', kr: '5분', en: '5m' },
 	{ v: 'D', kr: '일', en: 'D' },
 	{ v: 'W', kr: '주', en: 'W' },
 	{ v: 'M', kr: '월', en: 'M' },
 	{ v: 'Q', kr: '분기', en: 'Q' },
 	{ v: 'Y', kr: '년', en: 'Y' }
 ];
-export const TF_DIV: Record<TfKey, number> = { D: 1, W: 5, M: 21, Q: 63, Y: 252 };
+export const TF_DIV: Record<TfKey, number> = { '1m': 1, '3m': 1, '5m': 1, D: 1, W: 5, M: 21, Q: 63, Y: 252 };
 export const YMODES: { v: YMode; kr: string; en: string }[] = [
 	{ v: 'normal', kr: '일반', en: 'Linear' },
 	{ v: 'log', kr: '로그', en: 'Log' },

--- a/ui/packages/surfaces/src/terminal/lib/livePrice.ts
+++ b/ui/packages/surfaces/src/terminal/lib/livePrice.ts
@@ -1,10 +1,11 @@
-// 라이브 시세 훅 (증권사 API) — 키 노출 금지 설계.
-// 정적 사이트에 증권사 API 키를 직접 넣을 수 없으므로(공개=탈취), 키는 엣지 Worker 시크릿에만 둔다.
-// 프론트는 그 Worker URL 만 호출 → Worker 가 REST quote 프록시 또는 KIS websocket approval_key 발급.
+// 라이브 시세 훅 — 키 노출 금지 설계.
+// 로컬 DartLab 서버가 KIS/네이버 quote·minute endpoint 를 서버측 프록시로 호출한다.
+// 공개 정적 빌드에서 유료 증권사/KIS 키를 브라우저에 넣지 않는다.
 //
-//   VITE_DARTLAB_QUOTE_WORKER = https://<your-worker>.workers.dev   (미설정 시 라이브 비활성)
+//   로컬: same-origin /api/dartlab/live/*
+//   선택: VITE_DARTLAB_QUOTE_WORKER = https://<your-worker>.workers.dev
 //
-// 키 발급 전(또는 미설정) → null 반환 → 호출측은 EOD(전일 종가)까지만 표시. ("키 없으면 어제까지")
+// 서버/Worker 미설정 또는 실패 → null 반환 → 호출측은 EOD 가격을 유지한다.
 const browser = typeof window !== 'undefined'; // $app/environment 결합 제거 (4a-3)
 
 // vite 환경 안전 캐스트 — 빌드타임 설정(셸 무관 이식성, origin.ts VITE_DARTLAB_HF_RESOLVE 동일 패턴)
@@ -13,22 +14,86 @@ const WORKER_URL = viteEnv?.VITE_DARTLAB_QUOTE_WORKER ?? '';
 
 export interface LiveQuote {
 	code: string;
-	last: number;
-	change: number; // %
-	at: number; // epoch ms
+	name?: string;
+	price: number;
+	changeAmount: number;
+	changeRate: number;
+	open?: number | null;
+	high?: number | null;
+	low?: number | null;
+	volume?: number | null;
+	tradedValue?: number | null;
+	marketCap?: number | null;
+	marketStatus?: string;
+	marketStatusLabel?: string;
+	isLive: boolean;
+	provider: 'kis' | 'naver' | string;
+	refreshIntervalMs?: number;
+	tradedAt: string;
+	updatedAt: string;
+}
+
+export type MinuteTimeframe = '1m' | '3m' | '5m';
+
+export interface MinuteBar {
+	t: string;
+	o: number;
+	h: number;
+	l: number;
+	c: number;
+	v: number;
+}
+
+export interface MinuteBarsResponse {
+	code: string;
+	provider: 'kis' | 'naver' | string;
+	currency: 'KRW' | string;
+	basisDate: string;
+	isFallbackDate?: boolean;
+	timeframe: MinuteTimeframe;
+	bars: MinuteBar[];
+	updatedAt: string;
+}
+
+function localApi(path: string): string {
+	return path;
+}
+
+function workerApi(path: string): string {
+	return `${WORKER_URL.replace(/\/+$/, '')}${path}`;
 }
 
 export function liveEnabled(): boolean {
-	return browser && !!WORKER_URL;
+	return browser;
 }
 
 /** 라이브 last 시세. Worker 미설정/실패 → null (EOD fallback). */
 export async function fetchLiveQuote(stockCode: string): Promise<LiveQuote | null> {
 	if (!liveEnabled()) return null;
+	const path = `/api/dartlab/live/quote?code=${encodeURIComponent(stockCode)}`;
+	const urls = [localApi(path), ...(WORKER_URL ? [workerApi(`/quote/${encodeURIComponent(stockCode)}`)] : [])];
+	for (const url of urls) {
+		try {
+			const r = await fetch(url, { cache: 'no-store' });
+			if (!r.ok) continue;
+			const data = (await r.json()) as LiveQuote;
+			if (data && Number.isFinite(data.price)) return data;
+		} catch {
+			// try next source
+		}
+	}
+	return null;
+}
+
+/** 단일 종목 1/3/5분봉. 실패 → null (기존 차트 유지). */
+export async function fetchMinuteBars(stockCode: string, timeframe: MinuteTimeframe): Promise<MinuteBarsResponse | null> {
+	if (!liveEnabled()) return null;
 	try {
-		const r = await fetch(`${WORKER_URL.replace(/\/+$/, '')}/quote/${encodeURIComponent(stockCode)}`);
+		const qs = new URLSearchParams({ code: stockCode, timeframe });
+		const r = await fetch(localApi(`/api/dartlab/live/minute?${qs.toString()}`), { cache: 'no-store' });
 		if (!r.ok) return null;
-		return (await r.json()) as LiveQuote;
+		const data = (await r.json()) as MinuteBarsResponse;
+		return Array.isArray(data.bars) && data.bars.length ? data : null;
 	} catch {
 		return null;
 	}


### PR DESCRIPTION
## Summary
- add `/api/dartlab/live/quote` and `/api/dartlab/live/minute` for current quote and 1m/3m/5m bars
- use Naver Finance by default/fallback, with optional server-side KIS support when credentials are configured
- add 1m/3m/5m timeframes to the existing terminal price chart rather than a separate chart panel
- reflect the selected symbol web quote in the chart ribbon and a live price line, even without KIS
- update minute bars with the latest selected-symbol quote; use 0.5s polling for KIS and provider-paced polling for Naver

## Notes
- No brokerage credentials are exposed to the browser or committed in the repo.
- `DARTLAB_KIS_DISABLE=1` forces Naver-only behavior.
- Optional KIS credential paths can be configured with `DARTLAB_KIS_APP_KEY_PATH` and `DARTLAB_KIS_APP_SECRET_PATH`; if not present, the live endpoints fall back to Naver.

## Validation
- `uv run python -m py_compile src/dartlab/server/api/live.py src/dartlab/server/api/__init__.py src/dartlab/server/__init__.py`
- `npm --workspace @dartlab/ui-local run check` (0 errors; existing warnings remain)
- `npm --workspace @dartlab/ui-local run build`
- Manual Naver-only local check for quote plus 1m/3m/5m minute bars
